### PR TITLE
Added useNativeDriver to prevent RN crashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,6 +97,7 @@ class Snackbar extends Component {
         duration: durationValues.entry,
         toValue: 1,
         easing: easingValues.entry,
+        useNativeDriver: false,
       }).start();
       if (nextProps.autoHidingTime) {
         const hideFunc = this.hideSnackbar.bind(this);
@@ -127,6 +128,7 @@ class Snackbar extends Component {
       duration: durationValues.exit,
       toValue: 0,
       easing: easingValues.exit,
+      useNativeDriver: false,
     }).start();
   }
 }


### PR DESCRIPTION
Hi @smartameer,

this is quite a small PR, though as most other SnackBar components are quite bloated, I gave yours a try in 
a corporate gig I'm currently working at as sole developer. Using `patch-package` I got this to run, as it
was missing `useNativeDriver` (which I had to set to `false`, as `height` is no natively animatable property % ).

Hope you might merge it and publish a new version, as as patch-package sometimes breaks our Bamboo builds ; ).

Best,

Tim.